### PR TITLE
chore: switch deployment filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,5 +36,6 @@ workflows:
           context: cci-config-sdk-publishing
           filters:
             branches:
-              only: 
-                - main
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/


### PR DESCRIPTION
All builds were previously building on main. This ensures builds are only deployed on semver tags. 