### PR TITLE
fix: Parameters now have their type applied

### DIFF
--- a/src/components/atoms/form/InspectorProperty.tsx
+++ b/src/components/atoms/form/InspectorProperty.tsx
@@ -1,5 +1,5 @@
 import { Field, useField } from 'formik';
-import { ReactElement } from 'react';
+import { ReactElement, useEffect } from 'react';
 
 export interface InspectorFieldProps {
   label: string;
@@ -7,15 +7,27 @@ export interface InspectorFieldProps {
   as?: string;
   type?: string;
   value?: any;
+  hidden?: boolean;
   required?: boolean;
   onChange?: (e: any) => void;
   children?: ReactElement[] | ReactElement;
 }
 
 const InspectorProperty = ({ label, ...props }: InspectorFieldProps) => {
-  const [field] = useField(props);
+  const [field, meta, helper] = useField(props);
+
+  // Sync form value to the prop value on mount
+  useEffect(() => {
+    if (props.value && meta.value !== props.value) {
+      helper.setValue(props.value);
+    }
+  }, [props.value, helper, meta]);
+
   return (
-    <div className={`${props.type === 'checkbox' && `flex flex-row`} mb-3`}>
+    <div
+      className={`${props.type === 'checkbox' && `flex flex-row`} mb-3`}
+      hidden={props.hidden}
+    >
       <div className="flex flex-row mb-2">
         <p className="font-bold leading-5 tracking-wide">{label}</p>
         {props.required && (

--- a/src/components/containers/inspector/ParameterInspector.tsx
+++ b/src/components/containers/inspector/ParameterInspector.tsx
@@ -11,9 +11,15 @@ const ParameterInspector = (
 ) => {
   return (
     <div>
+      <InspectorProperty
+        name="type"
+        label="Type"
+        hidden
+        value={props.subtype}
+      />
       <InspectorProperty name="name" label="Name" required />
       <InspectorProperty name="description" label="Description" />
-      {parameterSubtypes[props.values.type]?.fields}
+      {props.subtype && parameterSubtypes[props.subtype]?.fields}
     </div>
   );
 };

--- a/src/components/menus/definitions/InspectorDefinitionMenu.tsx
+++ b/src/components/menus/definitions/InspectorDefinitionMenu.tsx
@@ -77,7 +77,7 @@ const InspectorDefinitionMenu = (props: InspectorDefinitionProps) => {
             const definition = definitions[dataMapping.type];
 
             const names = definition.map((d) => d.name);
-            const isNameDuplicate = names.includes(values.name);
+            const isNameDuplicate = names.includes(values.name.trim());
 
             if (isNameDuplicate) errors.name = 'Name is already in use';
 

--- a/src/components/menus/definitions/InspectorDefinitionMenu.tsx
+++ b/src/components/menus/definitions/InspectorDefinitionMenu.tsx
@@ -75,12 +75,12 @@ const InspectorDefinitionMenu = (props: InspectorDefinitionProps) => {
             // TODO: define error type
             const errors: any = {};
             const definition = definitions[dataMapping.type];
-            
-            const names = definition.map((d) => d.name);
+
+            const names = definition.map((d) => d.name.trim());
             const isNameDuplicate = names.includes(values.name);
 
             if (isNameDuplicate) errors.name = 'Name is already in use';
-        
+
             return errors;
             // TODO: handle error handling
             // const newDefinition = dataMapping.transform(values, definitions);

--- a/src/components/menus/definitions/InspectorDefinitionMenu.tsx
+++ b/src/components/menus/definitions/InspectorDefinitionMenu.tsx
@@ -76,7 +76,7 @@ const InspectorDefinitionMenu = (props: InspectorDefinitionProps) => {
             const errors: any = {};
             const definition = definitions[dataMapping.type];
 
-            const names = definition.map((d) => d.name.trim());
+            const names = definition.map((d) => d.name);
             const isNameDuplicate = names.includes(values.name);
 
             if (isNameDuplicate) errors.name = 'Name is already in use';


### PR DESCRIPTION
- Added explicit hidden InspectorProperty for parameter type
- Sync InspectorProperty's value if it is not equal to the meta (initial form) value.
- Trim name during map