### PR TITLE
fix: Adding parameters to commands and executors

### DIFF
--- a/src/components/containers/ParametersContainer.tsx
+++ b/src/components/containers/ParametersContainer.tsx
@@ -11,6 +11,8 @@ const ParameterContainer = (props: {
   const [field] = useField(props.values.parameters);
   const navigateTo = useStoreActions((actions) => actions.navigateTo);
 
+  console.log(props.values);
+
   return (
     <FieldArray
       {...field}
@@ -34,7 +36,9 @@ const ParameterContainer = (props: {
                       dataType: ParameterMapping,
                       passBackKey: 'parameters',
                       index: -1,
-                      source: props.values.parameters ? Object.keys(props.values.parameters) : undefined
+                      source: props.values.parameters
+                        ? Object.keys(props.values.parameters)
+                        : undefined,
                     },
                   },
                   props.values,
@@ -62,7 +66,7 @@ const ParameterContainer = (props: {
                   )}
                   {parameter.defaultValue ? (
                     <p className="text-sm mt-1 leading-4 whitespace-pre-wrap text-circle-gray-500">
-                      {parameter.description}
+                      {parameter.defaultValue}
                     </p>
                   ) : (
                     <p className="text-sm mt-1 leading-4 whitespace-pre-wrap text-circle-gray-500">

--- a/src/components/containers/ParametersContainer.tsx
+++ b/src/components/containers/ParametersContainer.tsx
@@ -11,8 +11,6 @@ const ParameterContainer = (props: {
   const [field] = useField(props.values.parameters);
   const navigateTo = useStoreActions((actions) => actions.navigateTo);
 
-  console.log(props.values);
-
   return (
     <FieldArray
       {...field}

--- a/src/components/menus/definitions/InspectorDefinitionMenu.tsx
+++ b/src/components/menus/definitions/InspectorDefinitionMenu.tsx
@@ -121,14 +121,15 @@ const InspectorDefinitionMenu = (props: InspectorDefinitionProps) => {
               apply: (parentValues) => {
                 if (props.passBackKey) {
                   const { name, ...args } = values;
-                  if (parentValues[props.passBackKey]) {
-                    parentValues[props.passBackKey][name] = args;
-                  } else {
-                    parentValues[props.passBackKey] = { [name]: args };
-                  }
-                }
 
-                return parentValues;
+                  return {
+                    ...parentValues,
+                    [props.passBackKey]: {
+                      ...parentValues[props.passBackKey],
+                      [name]: args,
+                    },
+                  };
+                }
               },
             });
             generateConfig();

--- a/src/mappings/ExecutorMapping.tsx
+++ b/src/mappings/ExecutorMapping.tsx
@@ -67,7 +67,6 @@ const ExecutorMapping: ComponentMapping<
   },
   parameters: componentParametersSubtypes.executor,
   transform: ({ name, ...values }) => {
-    console.log(values);
     return parsers.parseReusableExecutor(name, values);
   },
   store: {

--- a/src/mappings/ExecutorMapping.tsx
+++ b/src/mappings/ExecutorMapping.tsx
@@ -67,6 +67,7 @@ const ExecutorMapping: ComponentMapping<
   },
   parameters: componentParametersSubtypes.executor,
   transform: ({ name, ...values }) => {
+    console.log(values);
     return parsers.parseReusableExecutor(name, values);
   },
   store: {

--- a/src/state/Store.tsx
+++ b/src/state/Store.tsx
@@ -297,10 +297,25 @@ const Actions: StoreActions = {
 
       const values =
         payload?.apply?.(travelTo.props.values) || travelTo.props.values;
-      const props = {
-        ...travelTo.props,
-        values: values,
-      };
+      let props;
+
+      /**
+       * Solution for modifying props on sub menus.
+       */
+      if (travelTo.props?.menuProps) {
+        props = {
+          ...travelTo.props,
+          menuProps: {
+            ...travelTo.props.menuProps,
+            values: values,
+          },
+        };
+      } else {
+        props = {
+          ...travelTo.props,
+          values: values,
+        };
+      }
 
       state.navigation = {
         ...travelTo,


### PR DESCRIPTION
There was a bug where the subtype menu would not get the props from the navigateBack apply method. This implements that to fix executors. 