### PR TITLE
feat: Export embedded executor now requires confirmation

### DIFF
--- a/src/components/atoms/Select.tsx
+++ b/src/components/atoms/Select.tsx
@@ -42,8 +42,6 @@ const SelectField = ({
       onChange={(value) => {
         setValue(props.transform ? props.transform(value) : value);
 
-        console.log(value);
-
         props.onChange && props.onChange(value);
       }}
     />

--- a/src/components/atoms/form/ListProperty.tsx
+++ b/src/components/atoms/form/ListProperty.tsx
@@ -42,7 +42,7 @@ const ListItem = ({
   lastRemaining,
 }: ListItemProps) => {
   const updateConfirmation = useStoreActions(
-    (actions) => actions.updateConfirmation,
+    (actions) => actions.triggerConfirmation,
   );
   return (
     <Draggable key={index} draggableId={`${index}`} index={index}>
@@ -61,7 +61,7 @@ bg-white border border-circle-gray-300 hover:border-circle-black rounded-md2 fle
             <button
               onClick={() => {
                 updateConfirmation({
-                  type: 'delete',
+                  modalDialogue: 'delete',
                   labels: [`Step ${values.name}`],
                   onConfirm: () => arrayHelper.remove(index),
                 });

--- a/src/components/containers/ConfirmationModal.tsx
+++ b/src/components/containers/ConfirmationModal.tsx
@@ -3,14 +3,26 @@ import { useStoreActions, useStoreState } from '../../state/Hooks';
 import { Button, ButtonVariant } from '../atoms/Button';
 
 export type ConfirmationType = 'save' | 'delete';
+export type ConfirmationDialogue = {
+  header: string;
+  body: string;
+  button: string;
+  buttonVariant: ButtonVariant;
+};
 
-export type ConfirmationDialogue = Record<
+export type ConfirmationModalModel = {
+  modalDialogue: ConfirmationType | ConfirmationDialogue;
+  labels: string[];
+  onConfirm: () => void;
+};
+
+export type ConfirmationDialogueTemplates = Record<
   ConfirmationType,
-  { header: string; body: string; button: string; buttonVariant: ButtonVariant }
+  ConfirmationDialogue
 >;
 
 const placeholder = '%s';
-const confirmDialogue: ConfirmationDialogue = {
+const confirmDialogue: ConfirmationDialogueTemplates = {
   save: {
     header: `Do you want to save changes to ${placeholder}?`,
     body: 'If you choose not to save, your changes will be lost.',
@@ -28,10 +40,13 @@ const confirmDialogue: ConfirmationDialogue = {
 const ConfirmationModal = () => {
   const confirm = useStoreState((state) => state.confirm);
   const updateConfirmation = useStoreActions(
-    (actions) => actions.updateConfirmation,
+    (actions) => actions.triggerConfirmation,
   );
 
-  const dialogue = confirmDialogue[confirm?.type || 'save'];
+  const dialogue =
+    typeof confirm?.modalDialogue === 'string'
+      ? confirmDialogue[confirm.modalDialogue]
+      : confirm?.modalDialogue;
   const dialogueBox = { x: 478, y: 250 };
   const closeHandler = () => {
     updateConfirmation(undefined);
@@ -56,7 +71,7 @@ const ConfirmationModal = () => {
   // implement dialog dictionary, make it pretty, functionality first bro, get components to delete
   return (
     <>
-      {confirm && (
+      {confirm && dialogue && (
         <div
           className="absolute left-0 top-0 w-full h-full z-50 flex"
           style={{ background: 'rgba(20,20,20,.8)' }}
@@ -86,14 +101,14 @@ const ConfirmationModal = () => {
                   Cancel
                 </Button>
                 <Button
-                  variant="dangerous"
+                  variant={dialogue.buttonVariant}
                   type="button"
                   onClick={() => {
                     confirm.onConfirm();
                     updateConfirmation(undefined);
                   }}
                 >
-                  Delete
+                  {dialogue.button}
                 </Button>
               </div>
             </div>

--- a/src/components/containers/inspector/JobInspector.tsx
+++ b/src/components/containers/inspector/JobInspector.tsx
@@ -41,6 +41,11 @@ const EmbeddedExecutor = ({
   definitions: DefinitionsModel;
 } & FormikValues) => {
   const defineExecutor = useStoreActions((actions) => actions.define_executors);
+  const updateConfirmation = useStoreActions(
+    (actions) => actions.triggerConfirmation,
+  );
+
+  const triggerToast = useStoreActions((actions) => actions.triggerToast);
   const embeddedHelper = useField({
     name: embeddedExecutor,
     ...props,
@@ -58,14 +63,31 @@ const EmbeddedExecutor = ({
           type="button"
           className="ml-auto tracking-wide leading-6 text-sm text-circle-blue font-medium  "
           onClick={() => {
-            if (!(data.executor instanceof executors.Executor)) {
-              return;
-            }
-
             const name = data.name + '-exec-export';
-            embeddedHelper.setValue(undefined);
-            defineExecutor(data.executor.asReusable(name));
-            executor.setValue(name);
+
+            updateConfirmation({
+              onConfirm: () => {
+                if (!(data.executor instanceof executors.Executor)) {
+                  return;
+                }
+
+                embeddedHelper.setValue(undefined);
+                defineExecutor(data.executor.asReusable(name));
+                executor.setValue(name);
+                triggerToast({
+                  label: name,
+                  content: 'has been exported.',
+                  status: 'success',
+                });
+              },
+              modalDialogue: {
+                body: 'Upon extracting this %s, a %s with the name %s will be created. This operation cannot be undone.',
+                button: 'Confirm',
+                buttonVariant: 'primary',
+                header: 'Confirm Executor Export',
+              },
+              labels: ['executor', 'reusable executor', name],
+            });
           }}
         >
           Export as Definition

--- a/src/components/menus/definitions/InspectorDefinitionMenu.tsx
+++ b/src/components/menus/definitions/InspectorDefinitionMenu.tsx
@@ -82,7 +82,7 @@ const InspectorDefinitionMenu = (props: InspectorDefinitionProps) => {
   }
 
   const updateConfirmation = useStoreActions(
-    (actions) => actions.updateConfirmation,
+    (actions) => actions.triggerConfirmation,
   );
   return (
     <div className="h-full flex flex-col">
@@ -230,7 +230,7 @@ const InspectorDefinitionMenu = (props: InspectorDefinitionProps) => {
                     type="button"
                     onClick={() => {
                       updateConfirmation({
-                        type: 'delete',
+                        modalDialogue: 'delete',
                         labels: [dataMapping.name.singular, props.data.name],
                         onConfirm: () => {
                           deleteDefinition(props.data);

--- a/src/components/panes/NavigationPane.tsx
+++ b/src/components/panes/NavigationPane.tsx
@@ -21,7 +21,7 @@ const NavigationPane = ({ width }: NavigationPaneProps) => {
     >
       <NavPage {...navigation.props} />
       <div
-        className="p-6 absolute bottom-0 right-0 my-10 pointer-events-none"
+        className="p-6 absolute bottom-0 right-0 my-20 pointer-events-none"
         style={{ width: inspectorWidth }}
       >
         <Toast />


### PR DESCRIPTION
- Updated toast model to have custom template
- added a trigger toast action, to trigger a toast whenever
- Added confirmation for exporting embedded executor