### PR TITLE
refactor(ExecutorMapping): Bump defaults and improve wording

### DIFF
--- a/src/mappings/components/ExecutorMapping.tsx
+++ b/src/mappings/components/ExecutorMapping.tsx
@@ -51,14 +51,14 @@ export const ExecutorMapping: InspectableMapping<
     machine: {
       name: 'new-machine-executor',
       machine: {
-        image: 'ubuntu-2004:202111-01',
+        image: 'ubuntu-2204:2022.07.1',
       },
       resource_class: 'medium',
     },
     macos: {
       name: 'new-macos-executor',
       macos: {
-        xcode: '13.2.0',
+        xcode: '14.0.0',
       },
       resource_class: 'medium',
     },
@@ -117,7 +117,7 @@ export const ExecutorMapping: InspectableMapping<
   },
   docsInfo: {
     description:
-      'An %s technology or environment which Jobs execute their steps inside of.',
+      'An %s is a technology or environment in which Jobs execute their steps inside of.',
     link: 'https://circleci.com/docs/executor-types/',
   },
 };


### PR DESCRIPTION
Love the project!  A few of my colleagues are using it already, and getting more comfortable with it.  Kudos!  👏🏻 

When a user selects to add an executor, two of the technologies were slightly older versions. This PR bumps two of the executors to their latest defaults, with a goal to help ensure users creating a new pipeline are using the latest/greatest/patched. I can appreciate this project may not want to just continue to manage this long term, and the topic as a whole (pinning versions for stability vs. latest/stable for always patched) is complex.  Overtime, the project may want more automation around it, say collecting the latest/most recently published dynamically and presenting that, but for now just a small bump.

Also a small improvement in the wording of what an executor is, so it sort of fits in better with the other descriptions:

<img width="394" alt="image" src="https://user-images.githubusercontent.com/33203301/185631525-b96a66f8-de70-4b7d-abc4-219cafccf81d.png">

