### PR TITLE
fix: Description of Add SSH Keys step

### DIFF
--- a/src/components/containers/inspector/subtypes/CommandSubtypes.tsx
+++ b/src/components/containers/inspector/subtypes/CommandSubtypes.tsx
@@ -65,7 +65,7 @@ const commandSubtypes: CommandSubTypes = {
     name: 'Add SSH Keys',
     docsLink: `${sourceURL}#checkout`,
     description:
-      'A special step used to check out source code to the configured path',
+      'Add SSH keys so jobs check out code or access other services',
     fields: (
       <ListProperty
         addButton


### PR DESCRIPTION
Signed-off-by: Adam Harvey <adaharve@cisco.com>

This PR fixes a copy pasta typo in the description of the Add SSH Keys step.

| Before | After |
| --- | --- |
| <img width="354" alt="image" src="https://user-images.githubusercontent.com/33203301/191092318-c3ef4a99-42ef-42d8-80b3-b2728a528f52.png"> |  <img width="354" alt="image" src="https://user-images.githubusercontent.com/33203301/191092372-abd1a044-5015-419e-8d3c-ed5c518a5d25.png"> |