### PR TITLE
fix: Link to different command

### DIFF
--- a/src/components/containers/inspector/subtypes/CommandSubtypes.tsx
+++ b/src/components/containers/inspector/subtypes/CommandSubtypes.tsx
@@ -63,7 +63,7 @@ const commandSubtypes: CommandSubTypes = {
   },
   add_ssh_keys: {
     name: 'Add SSH Keys',
-    docsLink: `${sourceURL}#checkout`,
+    docsLink: `${sourceURL}#add-ssh-keys`,
     description:
       'A special step used to check out source code to the configured path',
     fields: (


### PR DESCRIPTION
Signed-off-by: Adam Harvey <adaharve@cisco.com>

#289 fixed the description below the Add SSH Keys element.  When merged and I looked again at the diff, I realized I had actually also missed that the href link was bad too!  So apologies for the chained PR, but this one fixes the link to the CircleCI documentation as well.